### PR TITLE
Handling Unknown Events for TokenEventProcessor

### DIFF
--- a/type-alias-axon-serializer/src/main/java/org/alias/axon/serializer/experimental/AliasableResourceBundleClassloader.java
+++ b/type-alias-axon-serializer/src/main/java/org/alias/axon/serializer/experimental/AliasableResourceBundleClassloader.java
@@ -48,7 +48,7 @@ public class AliasableResourceBundleClassloader extends ClassLoader {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
     public Class findClass(String name) throws ClassNotFoundException {
 		if (!resourceBundle.containsKey(name)) {
-			return null;
+			throw new ClassNotFoundException();
 		}
 		Object value = resourceBundle.getObject(name);
 		if (value instanceof Class) {
@@ -67,7 +67,7 @@ public class AliasableResourceBundleClassloader extends ClassLoader {
 				}
 			}
 		}
-		return null;
+		throw new ClassNotFoundException();
     }
 
 	/**

--- a/type-alias-axon-serializer/src/main/java/org/alias/axon/serializer/experimental/AliasableResourceBundleClassloader.java
+++ b/type-alias-axon-serializer/src/main/java/org/alias/axon/serializer/experimental/AliasableResourceBundleClassloader.java
@@ -48,7 +48,7 @@ public class AliasableResourceBundleClassloader extends ClassLoader {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
     public Class findClass(String name) throws ClassNotFoundException {
 		if (!resourceBundle.containsKey(name)) {
-			throw new ClassNotFoundException();
+			return Class.forName(name);
 		}
 		Object value = resourceBundle.getObject(name);
 		if (value instanceof Class) {


### PR DESCRIPTION
If TokenEventProcessor is configured and if there are some "unkonwn" events, the event handling pauses with NullPointerException as payload type is set to null. Throwing ClassNotFoundException will let axon to handle it. 