### PR TITLE
Update to Java 11

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Java Continuous Integration
 
 on: [push]
 
@@ -9,11 +9,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'adopt'
+        java-version: 11
+        cache: 'maven'
+    - name: Build with Maven
+      run: mvn --batch-mode install --file pom.xml
+      
+    - name: Set up JDK 8 for integration tests
       uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
         java-version: 8
         cache: 'maven'
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+    - name: Build and run integration tests with Maven
+      working-directory: type-alias-axon-serializer-integration-test
+      run: mvn --batch-mode package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,8 @@
 	<properties>
 		<project.scm.id>GitHub</project.scm.id>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
+		<library.java.version>1.8</library.java.version>
 		
 		<maven.compiler.version>3.10.1</maven.compiler.version>
 		<maven.surefire.version>2.22.2</maven.surefire.version>
@@ -73,7 +74,6 @@
 		<module>type-alias</module>
 		<module>type-alias-example</module>
 		<module>type-alias-axon-serializer</module>
-		<module>type-alias-axon-serializer-integration-test</module>
 		<module>type-alias-jsonb-typereference</module>
 	</modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.joht.alias</groupId>
 	<artifactId>alias-parent</artifactId>
-	<version>1.1.3-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>alias</name>

--- a/type-alias-axon-serializer-integration-test/pom.xml
+++ b/type-alias-axon-serializer-integration-test/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.joht.alias</groupId>
 	<artifactId>type-alias-axon-serializer-integration-test</artifactId>
-	<version>1.1.3-SNAPSHOT</version>	
+	<version>2.0.0-SNAPSHOT</version>	
 	
 	<name>type-alias-axon-serializer-integration-test</name>
 	<description>Contains the integration test for the type alias aware axon serializer including a fully working demo configuration for axon using JavaEE 8.</description>

--- a/type-alias-axon-serializer-integration-test/pom.xml
+++ b/type-alias-axon-serializer-integration-test/pom.xml
@@ -1,18 +1,32 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>io.github.joht.alias</groupId>
-		<artifactId>alias-parent</artifactId>
-		<version>1.1.3-SNAPSHOT</version>
-	</parent>
-
+	<groupId>io.github.joht.alias</groupId>
 	<artifactId>type-alias-axon-serializer-integration-test</artifactId>
+	<version>1.1.3-SNAPSHOT</version>	
+	
 	<name>type-alias-axon-serializer-integration-test</name>
 	<description>Contains the integration test for the type alias aware axon serializer including a fully working demo configuration for axon using JavaEE 8.</description>
 	<url>https://github.com/JohT/alias/tree/master/type-alias-axon-serializer-integration-test</url>
 
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+
+	<scm>
+		<connection>scm:git:git://github.com/JohT/alias.git</connection>
+		<developerConnection>scm:git:git@github.com:JohT/alias.git</developerConnection>
+		<url>https://github.com/JohT/alias</url>
+		<tag>HEAD</tag>
+	</scm>
+
 	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.8</java.version>
+
 		<axon.version>4.5.14</axon.version>
 
 		<!-- Optional dependencies for axon -->
@@ -35,6 +49,17 @@
 
 		<!-- Unit testing -->
 		<equalsverifier.version>3.10</equalsverifier.version>
+		<junit-jupiter.version>5.8.2</junit-jupiter.version>
+		<hamcrest.version>2.2</hamcrest.version>
+		<mockito.version>1.10.19</mockito.version>
+		
+		<!-- Maven Plugins -->
+		<maven.compiler.version>3.10.1</maven.compiler.version>
+		<maven.surefire.version>2.22.2</maven.surefire.version>
+		<maven.failsafe.version>2.22.2</maven.failsafe.version>
+		<maven.assembly.version>3.3.0</maven.assembly.version>
+		<maven.dependency.version>3.3.0</maven.dependency.version>
+		<eclipse.lifecycle.mapping.version>1.0.0</eclipse.lifecycle.mapping.version>
 	</properties>
 
 	<dependencyManagement>
@@ -136,7 +161,6 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j.version}</version>
 		</dependency>
 
 		<dependency>
@@ -162,6 +186,7 @@
 		<dependency>
     		<groupId>org.junit.jupiter</groupId>
     		<artifactId>junit-jupiter</artifactId>
+    		<version>${junit-jupiter.version}</version>
     		<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -231,7 +256,7 @@
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
+					<version>${eclipse.lifecycle.mapping.version}</version>
 					<configuration>
 						<lifecycleMappingMetadata>
 							<pluginExecutions>
@@ -265,6 +290,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven.compiler.version}</version>
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
@@ -274,10 +300,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven.surefire.version}</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${maven.failsafe.version}</version>
 				<executions>
 					<execution>
 						<goals>
@@ -290,7 +318,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>${maven.dependency.version}</version>
 				<executions>
 					<execution>
 						<id>unpack</id>

--- a/type-alias-axon-serializer/pom.xml
+++ b/type-alias-axon-serializer/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.github.joht.alias</groupId>
 		<artifactId>alias-parent</artifactId>
-		<version>1.1.3-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>type-alias-axon-serializer</artifactId>

--- a/type-alias-axon-serializer/pom.xml
+++ b/type-alias-axon-serializer/pom.xml
@@ -44,4 +44,24 @@
 		</dependency>
 		
 	</dependencies>
+
+	<build>
+		<finalName>${project.artifactId}</finalName>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>${maven.compiler.version}</version>
+					<configuration>
+						<source>${library.java.version}</source>
+						<target>${library.java.version}</target>
+						<encoding>${project.build.sourceEncoding}</encoding>
+						<compilerArgs>
+							<arg>-proc:none</arg>
+						</compilerArgs>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 </project>

--- a/type-alias-axon-serializer/pom.xml
+++ b/type-alias-axon-serializer/pom.xml
@@ -14,7 +14,6 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
 		<axon.version>4.5.14</axon.version>
 	</properties>
 

--- a/type-alias-example/pom.xml
+++ b/type-alias-example/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.github.joht.alias</groupId>
 		<artifactId>alias-parent</artifactId>
-		<version>1.1.3-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>type-alias-example</artifactId>

--- a/type-alias-jsonb-typereference/pom.xml
+++ b/type-alias-jsonb-typereference/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.github.joht.alias</groupId>
 		<artifactId>alias-parent</artifactId>
-		<version>1.1.3-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>type-alias-jsonb-typereference</artifactId>
 

--- a/type-alias/pom.xml
+++ b/type-alias/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.github.joht.alias</groupId>
 		<artifactId>alias-parent</artifactId>
-		<version>1.1.3-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>type-alias</artifactId>

--- a/type-alias/pom.xml
+++ b/type-alias/pom.xml
@@ -40,8 +40,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>${maven.compiler.version}</version>
 					<configuration>
-						<source>${java.version}</source>
-						<target>${java.version}</target>
+						<source>${library.java.version}</source>
+						<target>${library.java.version}</target>
 						<encoding>${project.build.sourceEncoding}</encoding>
 						<compilerArgs>
 							<arg>-proc:none</arg>


### PR DESCRIPTION
### Changes:

- Use Java 11 instead of Java 1.8 as default
- Still use Java 1.8 for the main library "type-alias" and "type-alias-axon-serializer" to retain full compatibility
- Separate integration tests to compile them with Java 1.8 within a Java 1.8 JDK until problems with Java 11 are solved