### PR TITLE
Provide version number independent wildfly distribution folder

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,15 +8,5 @@
     ":automergeRequireAllStatusChecks",
     ":ignoreUnstable",
     "group:recommended"
-  ],
-  "regexManagers": [
-    {
-      "fileMatch": ["(^|/|\\.)arquillian\\.xml$"],
-      "matchStrings": [
-        "property\\s+name\\s?=\\s?\"jbossHome\"\\s?\\>\\$\\{jbossHome\\:[\\w\/]+?\\-(?<currentValue>.*?)\\}"
-      ],
-      "depNameTemplate": "wildfly/wildfly",
-      "datasourceTemplate": "github-releases"
-    }
   ]
 }

--- a/type-alias-axon-serializer-integration-test/pom.xml
+++ b/type-alias-axon-serializer-integration-test/pom.xml
@@ -3,8 +3,8 @@
 
 	<groupId>io.github.joht.alias</groupId>
 	<artifactId>type-alias-axon-serializer-integration-test</artifactId>
-	<version>2.0.0-SNAPSHOT</version>	
-	
+	<version>2.0.0-SNAPSHOT</version>
+
 	<name>type-alias-axon-serializer-integration-test</name>
 	<description>Contains the integration test for the type alias aware axon serializer including a fully working demo configuration for axon using JavaEE 8.</description>
 	<url>https://github.com/JohT/alias/tree/master/type-alias-axon-serializer-integration-test</url>
@@ -52,13 +52,14 @@
 		<junit-jupiter.version>5.9.0</junit-jupiter.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<mockito.version>1.10.19</mockito.version>
-		
+
 		<!-- Maven Plugins -->
 		<maven.compiler.version>3.10.1</maven.compiler.version>
 		<maven.surefire.version>2.22.2</maven.surefire.version>
 		<maven.failsafe.version>2.22.2</maven.failsafe.version>
 		<maven.assembly.version>3.3.0</maven.assembly.version>
 		<maven.dependency.version>3.3.0</maven.dependency.version>
+		<maven.resources.plugin.version>3.3.0</maven.resources.plugin.version>
 		<eclipse.lifecycle.mapping.version>1.0.0</eclipse.lifecycle.mapping.version>
 	</properties>
 
@@ -171,11 +172,11 @@
 		</dependency>
 
 		<dependency>
-    		<groupId>org.slf4j</groupId>
-    		<artifactId>log4j-over-slf4j</artifactId>
-    		<version>1.7.36</version>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
+			<version>1.7.36</version>
 		</dependency>
-  		
+
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
@@ -184,10 +185,10 @@
 
 		<!-- Unit Testing -->
 		<dependency>
-    		<groupId>org.junit.jupiter</groupId>
-    		<artifactId>junit-jupiter</artifactId>
-    		<version>${junit-jupiter.version}</version>
-    		<scope>test</scope>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${junit-jupiter.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
@@ -222,23 +223,23 @@
 			<scope>test</scope>
 		</dependency>
 
-        <dependency>
-            <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
-            <scope>test</scope>
-        </dependency>
-        
 		<dependency>
-    		<groupId>org.jboss.shrinkwrap.resolver</groupId>
-    		<artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-   		 <scope>test</scope>
+			<groupId>org.jboss.arquillian.protocol</groupId>
+			<artifactId>arquillian-protocol-servlet</artifactId>
+			<scope>test</scope>
 		</dependency>
-		
-        <dependency>
-            <groupId>org.jboss.arquillian.junit5</groupId>
-            <artifactId>arquillian-junit5-container</artifactId>
-            <scope>test</scope>
-        </dependency>
+
+		<dependency>
+			<groupId>org.jboss.shrinkwrap.resolver</groupId>
+			<artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jboss.arquillian.junit5</groupId>
+			<artifactId>arquillian-junit5-container</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -276,7 +277,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore/>
+										<ignore />
 									</action>
 								</pluginExecution>
 							</pluginExecutions>
@@ -337,6 +338,28 @@
 									<outputDirectory>${project.build.directory}</outputDirectory>
 								</artifactItem>
 							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>${maven.resources.plugin.version}</version>
+				<executions>
+					<execution>
+						<id>copy-wildfly</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/wildfly</outputDirectory>
+							<resources>
+								<resource>
+									<directory>${project.build.directory}/wildfly-${wildfly.version}</directory>
+								</resource>
+							</resources>
 						</configuration>
 					</execution>
 				</executions>

--- a/type-alias-axon-serializer-integration-test/src/test/resources/arquillian.xml
+++ b/type-alias-axon-serializer-integration-test/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
 
     <container qualifier="widlfly-managed" default="true">
         <configuration>
-            <property name="jbossHome">${jbossHome:target/wildfly-26.1.0.Final}</property>
+            <property name="jbossHome">${jbossHome:target/wildfly}</property>
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
### Changes

- Provide version number independent wildfly distribution folder so that `arquillian.xml` doesn't need to be changed for every new wildfly distribution name.