### PR TITLE
Axon 5 type alias serializer

### DIFF
--- a/.github/prompts/plan-typeAliasAxon5Serializer.prompt.md
+++ b/.github/prompts/plan-typeAliasAxon5Serializer.prompt.md
@@ -1,0 +1,195 @@
+# Plan: Axon 5 Serializer Adapter (type-alias-axon-5-serializer)
+
+## Context / Key Findings
+
+### Why a new artifact (not single v4+v5)
+- Axon 4: `Serializer` at `org.axonframework.serialization.Serializer` (in `axon-configuration`)
+- Axon 5: `Serializer` moved to `org.axonframework.conversion.Serializer` — different package = binary incompatible
+- `axon-configuration` does not exist in Axon 5; replaced by `axon-messaging`, `axon-conversion`, etc.
+- Two artifacts accepted: `type-alias-axon-5-serializer` + `type-alias-axon-5-serializer-integration-test`
+
+### Axon 5 type aliasing hook
+- **Axon 4**: hook via `Serializer.typeForClass(Class)` (store alias) and `classForType(SerializedType)` (resolve alias)
+- **Axon 5**: hook is `MessageTypeResolver` (in `axon-messaging`)
+  - `@FunctionalInterface` with `Optional<MessageType> resolve(Class<?> payloadType)`
+  - Used for BOTH write path (storing type name) AND handler routing (read path)
+  - Class resolution at handler invocation uses the handler's declared parameter type directly — no `classForType` needed
+  - Existing implementations: `ClassBasedMessageTypeResolver` (FQCN), `AnnotationMessageTypeResolver` (@Event/@Command annotations), `NamespaceMessageTypeResolver` (explicit map), `HierarchicalMessageTypeResolver` (chain)
+- The new library is actually **simpler** than the v4 one (single hook point vs. two)
+
+### Key decisions
+- Java 17+ for v5 library (Axon 5 requires Java 17)
+- Depend only on `type-alias` (core module) + `axon-messaging` 5.1.0 (both optional scope)
+- No dependency on `type-alias-axon-serializer`
+- Alias format: flat, e.g. `MessageType("AccountCreated", MessageType.DEFAULT_VERSION)` — alias as full qualified name
+- No Axon-internal type aliases (only user domain types)
+- Integration test: standalone JUnit 5, no WildFly/CDI/Arquillian
+- Integration test scope: minimal — prove aliasing works end-to-end
+
+### Axon 5.1.0 Maven artifacts (org.axonframework)
+- `axon-messaging` 5.1.0 — MessageTypeResolver, MessageType, QualifiedName
+- `axon-modelling` 5.1.0 — aggregate support (@AggregateRoot, @CommandHandler, @EventSourcingHandler)
+- `axon-eventsourcing` 5.1.0 — event storage
+- `axon-test` 5.1.0 — AggregateTestFixture
+- `axon-conversion` 5.1.0 — JacksonConverter (new) and deprecated Serializer (stash/legacy)
+
+---
+
+## Plan: type-alias-axon-5-serializer + integration-test
+
+### Phase 1: Core library — type-alias-axon-5-serializer
+
+**Step 1.1** Create `type-alias-axon-5-serializer/pom.xml`
+- Parent: `alias-parent 2.0.1-SNAPSHOT`
+- Java 17 source/target (unlike v4's Java 1.8)
+- Dependencies (all optional):
+  - `type-alias` (provided scope) — for @TypeAlias annotation + ResourceBundle structure
+  - `axon-messaging` 5.1.0 (optional) — MessageTypeResolver, MessageType
+- Test dependencies: junit-jupiter, hamcrest-core, mockito-core
+- Build: `-proc:none` (no annotation processing), maven-compiler-plugin Java 17
+
+**Step 1.2** Create `AliasableMessageTypeResolver.java`
+- Package: `org.alias.axon.serializer` (same base package as v4 for consistency)
+- `implements MessageTypeResolver`
+- Fields: `MessageTypeResolver delegate`, `Function<Class<?>, Optional<String>> aliasLookup`
+- Factory methods (analogous to TypeDecoratableSerializer):
+  - `aliasThroughDefaultResourceBundle(MessageTypeResolver delegate)` — uses "TypeAlias" ResourceBundle
+  - `aliasThroughResourceBundle(MessageTypeResolver delegate, ResourceBundle resourceBundle)` — explicit bundle
+- `resolve(Class<?> payloadType)`:
+  - Look up `payloadType.getName()` in ResourceBundle; if a String value exists → it's the alias
+  - Return `Optional.of(new MessageType(alias, MessageType.DEFAULT_VERSION))`
+  - Else → `delegate.resolve(payloadType)`
+- Note: ResourceBundle lookup is self-contained (20 lines), no dependency on v4 library
+
+**Step 1.3** Unit tests for `AliasableMessageTypeResolver` — **MUST HAVE** in BDD/TDD style
+- `AliasableMessageTypeResolverTest.java` (Behavior Driven Development style with clear spec):
+  - **Given** a ResourceBundle with an alias mapping, **when** resolving a type, **then** return MessageType with alias name
+  - **Given** a ResourceBundle without an alias mapping, **when** resolving a type, **then** delegate to fallback resolver  
+  - **Given** default factory method used, **when** resolving a type, **then** use "TypeAlias" ResourceBundle by convention
+  - **Given** null or empty alias values in ResourceBundle, **when** resolving, **then** safely handle and delegate
+  - Spec-style naming: `shouldReturnAliasWhenFoundInResourceBundle()`, `shouldDelegateWhenNoAliasFound()`, etc.
+- Tests written first (TDD), implementation follows
+- All tests must pass with 100% code coverage for `AliasableMessageTypeResolver`
+
+**Step 1.4** package-info.java pointing to `AliasableMessageTypeResolver#aliasThroughResourceBundle`
+
+### Phase 2: Integration test — type-alias-axon-5-serializer-integration-test
+
+**Step 2.1** Create `type-alias-axon-5-serializer-integration-test/pom.xml`
+- Parent: `alias-parent 2.0.1-SNAPSHOT`
+- Java 17 source/target
+- Dependencies:
+  - `type-alias-axon-5-serializer` (compile)
+  - `type-alias` (provided) — annotation processor
+  - `axon-messaging` 5.1.0
+  - `axon-modelling` 5.1.0
+  - `axon-eventsourcing` 5.1.0
+  - `axon-test` 5.1.0 (test scope)
+  - `axon-conversion` 5.1.0 (test scope) — JacksonConverter
+  - `jackson-databind` (test scope) — JSON serialization
+  - `junit-jupiter` (test scope)
+  - `hamcrest-core` (test scope)
+- NO arquillian, NO wildfly, NO reactor, NO CDI, NO JEE APIs
+- Build: maven-compiler-plugin Java 17, maven-surefire-plugin
+
+**Step 2.2** Domain model — minimal test aggregate
+- `messages/` package with `@TypeAlias`-annotated events:
+  - `SomethingHappenedEvent` with `@TypeAlias("SomethingHappened")`
+- `@TypeAliases` + `@TypeAliasGeneratedFile` on package-info.java → generates ResourceBundle
+- Aggregate: `SomethingAggregate` with @CommandHandler and @EventSourcingHandler
+
+**Step 2.3** Integration tests (plain JUnit 5, BDD style, **MUST HAVE**)
+- `TypeAliasMessageTypeResolverIT.java` (Behavior Driven Development):
+  1. **Given** an alias defined via `@TypeAlias("SomethingHappened")`, **when** resolving `SomethingHappenedEvent.class`, **then** return `MessageType("SomethingHappened", ...)`
+  2. **Given** an `AggregateTestFixture` configured with `AliasableMessageTypeResolver` and domain event with alias, **when** command dispatched and event published, **then** stored event's `MessageType.name()` equals "SomethingHappened" (not FQCN)
+  3. **Given** events stored under alias, **when** aggregate re-sourced from event store, **then** state correctly reconstructed
+- Test names follow spec style: `shouldResolveAliasFromAnnotation()`, `shouldStoreEventUnderAliasName()`, `shouldRestoreAggregateFromAliasedEvents()`
+- All integration tests must pass
+
+### Phase 3: Root POM update
+
+**Step 3.1** Add `type-alias-axon-5-serializer` to root `pom.xml` modules list
+- `type-alias-axon-5-serializer-integration-test` should NOT be in root modules (same as v4 pattern)
+
+### Relevant files
+- `pom.xml` (root) — add module entry for `type-alias-axon-5-serializer`
+- `type-alias-axon-serializer/pom.xml` — reference for v4 structure/patterns
+- `type-alias-axon-serializer/src/main/java/org/alias/axon/serializer/TypeDecoratableSerializer.java` — reference API pattern
+- `type-alias-axon-serializer/src/main/java/org/alias/axon/serializer/aliasable/AliasableTypeResourceBundleRegister.java` — reference ResourceBundle logic (DO NOT depend on; re-implement simply)
+- `type-alias-axon-serializer-integration-test/src/main/java/.../messages/` — reference for @TypeAlias annotations pattern
+
+### Verification steps
+1. `mvn install -pl type-alias-axon-5-serializer` — library builds without errors
+2. `mvn test -pl type-alias-axon-5-serializer` — unit tests pass
+3. `mvn test -pl type-alias-axon-5-serializer-integration-test` — integration tests pass
+4. Verify no compile dependency on `type-alias-axon-serializer` (v4 library)
+5. Verify `axon-messaging` is `optional` scope in library pom
+6. `mvn install` from root — root build includes new library module
+
+### Decisions
+- Single artifact impossible: binary incompatibility between Axon 4/5 Serializer packages
+- Axon 5 hook: `MessageTypeResolver` (simpler than v4's two-hook Serializer approach)
+- Alias format: flat `MessageType(alias, DEFAULT_VERSION)` — same as Axon 5's FQCN-based default, just alias string replaces FQCN
+- No Axon-internal aliases (GapAwareTrackingToken etc.) — only user domain types
+- No WildFly/CDI: removed entirely for v5 integration test
+- Java 17+ for v5 module (Axon 5 requirement)
+
+### Out of scope
+- Backward compatibility reading events stored with v4 alias names (upcaster territory)
+- Spring Boot auto-configuration bean for AliasableMessageTypeResolver
+- Support for @Event/@Command native Axon 5 annotations (users can chain AnnotationMessageTypeResolver before our resolver)
+
+### Guidelines
+
+#### Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+#### Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+#### Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+#### Unit Tests are Non-Negotiable
+
+**BDD/TDD style. Tests first, implementation second. Clear spec.**
+
+- **Every new class MUST have unit tests** — no exceptions.
+- Tests written in **Behavior Driven Development (BDD) style**:
+  - Use `Given/When/Then` structure in test names and comments
+  - Spec-style test names: `shouldReturnAliasWhenFoundInResourceBundle()`, not `testResolveAlias()`
+  - Each test verifies ONE behavior, not multiple assertions on different concerns
+  - Red → Green → Refactor cycle (TDD)
+- **100% code coverage** for production code
+- Use meaningful assertion messages (not default Hamcrest/JUnit messages)
+- Mock external dependencies; test behavior, not implementation details
+- No empty test files or placeholder tests

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -3,13 +3,16 @@
 Overview of the commands to test, run, build and release this project.
 
 ## Prerequisites
+
 - [Installing Apache Maven](https://maven.apache.org/install.html)
 
-## Most important commands for development:
+## Most important commands for development
+
 - `mvn verify` Builds the project and runs all tests including integration tests 
 - `mvn install` Includes `mvn verify` and copies the resulting artifacts into the local maven repository.
 
-## (maintainer) Commands to release a new version:
+## (maintainer) Commands to release a new version
+
 - `mvn clean` Starts off clean
 - `mvn release:prepare` Prepares a new version
 - `mvn release:perform` Performs the publish-ready release including tag and version number increment

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -8,8 +8,9 @@ Overview of the commands to test, run, build and release this project.
 
 ## Most important commands for development
 
-- `mvn verify` Builds the project and runs all tests including integration tests 
+- `mvn verify` Builds library modules and runs their tests (integration-test modules are not part of the root reactor)
 - `mvn install` Includes `mvn verify` and copies the resulting artifacts into the local maven repository.
+- To run integration tests, build the specific integration-test module explicitly (e.g., `mvn test -f type-alias-axon-5-serializer-integration-test/pom.xml`)
 
 ## (maintainer) Commands to release a new version
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+# alias
+
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.joht.alias/type-alias.svg?style=shield)](https://maven-badges.herokuapp.com/maven-central/io.github.joht.alias/type-alias/)
-# alias
 
 Java identifies types by their class name. 
 The class name heavily depends on implementation details (e.g. where the class is located).
@@ -34,9 +35,11 @@ that generates (by default) the ResourceBundle `TypeAlias.java` inside the defau
 ```
 
 ### Building this project
+
 Install maven and use `mvn install` to build this project, run all tests including the integration tests and copy the resulting artifacts into the local maven repository. A list of the most important commands can be found in [COMMANDS.md](COMMANDS.md).
 
 ### Changes
+
 All changes are listed in [CHANGELOG.md](./CHANGELOG.md). The file is generated automatically during "generate-resources" build phase based on merged pull requests and their tags.
 
 #### Breaking changes in Version 2.x
@@ -46,6 +49,7 @@ All changes are listed in [CHANGELOG.md](./CHANGELOG.md). The file is generated 
 - `type-alias-axon-serializer-integration-test` will no longer be published to maven central
 
 ### Contents
+
 - [type-alias](https://github.com/JohT/alias/tree/main/type-alias) 
 contains the main module with the java annotation processing based file generator.
 - [type-alias-example](https://github.com/JohT/alias/tree/main/type-alias-example) 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ that generates (by default) the ResourceBundle `TypeAlias.java` inside the defau
 
 ### Building this project
 
-Install maven and use `mvn install` to build this project, run all tests including the integration tests and copy the resulting artifacts into the local maven repository. A list of the most important commands can be found in [COMMANDS.md](COMMANDS.md).
+Install maven and use `mvn install` to build this project and copy the resulting artifacts into the local maven repository. Integration-test modules are not part of the root reactor and must be built explicitly. A list of the most important commands can be found in [COMMANDS.md](COMMANDS.md).
 
 ### Changes
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
 		<module>type-alias</module>
 		<module>type-alias-example</module>
 		<module>type-alias-axon-serializer</module>
+		<module>type-alias-axon-5-serializer</module>
 		<module>type-alias-jsonb-typereference</module>
 	</modules>
 

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,28 @@
       ],
       "groupName": "Java Development Kit (JDK)",
       "enabled": false
+    },
+    {
+      "description": "Keep Axon 4 modules on the latest 4.x version.",
+      "matchFileNames": [
+        "type-alias-axon-serializer/**",
+        "type-alias-axon-serializer-integration-test/**"
+      ],
+      "matchPackageNames": [
+        "org.axonframework:**"
+      ],
+      "allowedVersions": "<5.0.0"
+    },
+    {
+      "description": "Keep Axon 5 modules on the latest 5.x version.",
+      "matchFileNames": [
+        "type-alias-axon-5-serializer/**",
+        "type-alias-axon-5-serializer-integration-test/**"
+      ],
+      "matchPackageNames": [
+        "org.axonframework:**"
+      ],
+      "allowedVersions": ">=5.0.0 <6.0.0"
     }
   ],
   "customManagers": [

--- a/type-alias-axon-5-serializer-integration-test/README.md
+++ b/type-alias-axon-5-serializer-integration-test/README.md
@@ -1,0 +1,185 @@
+# Integration Tests and Examples for Type-Alias Message Type Resolver (Axon 5)
+
+This module contains integration tests and examples demonstrating how to use type aliases with Axon Framework 5.
+
+## Overview
+
+This example project shows:
+
+- How to define domain events and commands with `@TypeAlias` annotations
+- How to configure the `AliasableMessageTypeResolver` in an Axon 5 application
+- How to verify that events are published with aliased message types in integration tests
+- How the annotation processor automatically generates the type alias resource bundle
+
+## Running the Tests
+
+Run all integration tests:
+
+```bash
+mvn test
+```
+
+Or from the parent directory:
+
+```bash
+mvn test -f type-alias-axon-5-serializer-integration-test/pom.xml
+```
+
+## Example Structure
+
+### Domain Model
+
+The example uses a simple order scenario with:
+
+#### Commands
+
+- **`DoSomethingCommand`**: A simple command to trigger an event. Contains only an `aggregateId` field and relies on the default class-based type resolution for command routing (via `QualifiedName`).
+
+```java
+@ConstructorProperties({"aggregateId"})
+public class DoSomethingCommand {
+    private final String aggregateId;
+    // ...
+}
+```
+
+#### Events
+
+- **`SomethingHappenedEvent`**: A domain event annotated with `@TypeAlias("SomethingHappened")`. This demonstrates how aliases are used for event type resolution.
+
+```java
+@TypeAlias("SomethingHappened")
+public class SomethingHappenedEvent {
+    private final String aggregateId;
+    // ...
+}
+```
+
+### Package Configuration
+
+The `package-info.java` in the messages package:
+
+```java
+package org.alias.axon.serializer.example.messages;
+```
+
+This allows the annotation processor to collect all `@TypeAlias` annotations in the package and generate the `TypeAlias` resource bundle in the default package (required by `AliasableMessageTypeResolver.aliasThroughDefaultResourceBundle()`).
+
+## Integration Tests
+
+### Test 1: Alias Resolution
+
+**`shouldResolveAliasFromAnnotation()`**
+
+Verifies that the resolver correctly looks up the alias from the resource bundle:
+
+```java
+MessageTypeResolver resolver = AliasableMessageTypeResolver
+    .aliasThroughDefaultResourceBundle(new ClassBasedMessageTypeResolver());
+
+Optional<MessageType> result = resolver.resolve(SomethingHappenedEvent.class);
+
+assertThat(result.isPresent(), is(true));
+assertThat(result.get().name(), is("SomethingHappened"));
+```
+
+### Test 2: Event Publishing with Aliases
+
+**`shouldPublishEventWithAliasedMessageType()`**
+
+Uses `AxonTestFixture` to verify that when a command is dispatched, the resulting event carries the aliased message type name:
+
+```java
+fixture.given()
+    .noPriorActivity()
+    .when()
+    .command(new DoSomethingCommand("id1"))
+    .then()
+    .success()
+    .eventsSatisfy(events -> {
+        assertThat(events, hasSize(1));
+        assertThat(events.get(0).type().name(), is("SomethingHappened"));
+    });
+```
+
+This test:
+
+1. Configures Axon with the `AliasableMessageTypeResolver`
+2. Dispatches a `DoSomethingCommand`
+3. The command handler resolves the message type for `SomethingHappenedEvent` using the resolver
+4. Verifies the published event has the alias name "SomethingHappened" instead of the full class name
+
+## Key Configuration Points
+
+### Annotation Processor Setup
+
+The `pom.xml` includes explicit annotation processor path configuration:
+
+```xml
+<annotationProcessorPaths>
+    <path>
+        <groupId>io.github.joht.alias</groupId>
+        <artifactId>type-alias</artifactId>
+        <version>${project.version}</version>
+    </path>
+</annotationProcessorPaths>
+```
+
+This is required for Java 17+ to enable annotation processors on the classpath.
+
+### Test Locale Consistency
+
+The `pom.xml` configures Surefire with system properties to ensure consistent test behavior across different machines:
+
+```xml
+<systemPropertyVariables>
+    <user.language>en</user.language>
+    <user.country>US</user.country>
+</systemPropertyVariables>
+```
+
+## How to Extend the Example
+
+To add more domain events and commands:
+
+1. Create new classes in `src/main/java/org/alias/axon/serializer/example/messages/`
+2. Annotate events with `@TypeAlias("<YourAlias>")`
+3. Commands don't need aliases (they use `QualifiedName` for routing)
+4. Rebuild: `mvn clean compile`
+5. The annotation processor automatically updates the `TypeAlias` resource bundle
+6. Write integration tests to verify the behavior
+
+## Architecture Overview
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                    Axon Test Fixture                        │
+├─────────────────────────────────────────────────────────────┤
+│  • Registers AliasableMessageTypeResolver                   │
+│  • Configures command handling                              │
+│  • Records published events                                 │
+└─────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│            AliasableMessageTypeResolver                      │
+├─────────────────────────────────────────────────────────────┤
+│  • Looks up FQCN in TypeAlias resource bundle               │
+│  • Returns aliased MessageType if found                      │
+│  • Falls back to ClassBasedMessageTypeResolver              │
+└─────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│              Generated TypeAlias Resource Bundle             │
+├─────────────────────────────────────────────────────────────┤
+│  • Generated at compile time by annotation processor        │
+│  • Maps FQCN → Alias for all @TypeAlias classes            │
+│  • Located in default package (root of classpath)           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## References
+
+- [Axon Framework Documentation](https://docs.axoniq.io)
+- [Axon Test Fixtures](https://docs.axoniq.io/reference-guide/axon-framework/testing)
+- [type-alias Project](https://github.com/JohT/alias)
+- [Java Annotation Processing](https://docs.oracle.com/en/java/javase/17/docs/api/java.compiler/javax/annotation/processing/package-summary.html)

--- a/type-alias-axon-5-serializer-integration-test/pom.xml
+++ b/type-alias-axon-5-serializer-integration-test/pom.xml
@@ -1,0 +1,134 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>io.github.joht.alias</groupId>
+		<artifactId>alias-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>type-alias-axon-5-serializer-integration-test</artifactId>
+	<name>type-alias-axon-5-serializer-integration-test</name>
+	<description>Integration tests for the type alias aware MessageTypeResolver for Axon Framework 5.</description>
+	<url>https://github.com/JohT/alias/tree/main/type-alias-axon-5-serializer-integration-test</url>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<axon5.version>5.1.0</axon5.version>
+		<jackson.version>2.21.3</jackson.version>
+	</properties>
+
+	<dependencies>
+		<!-- Library under test -->
+		<dependency>
+			<groupId>io.github.joht.alias</groupId>
+			<artifactId>type-alias-axon-5-serializer</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!-- type-alias annotation processor (compile-time) -->
+		<dependency>
+			<groupId>io.github.joht.alias</groupId>
+			<artifactId>type-alias</artifactId>
+			<version>${project.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Required by the type-alias annotation processor for @Generated -->
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>${annotation.api.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Axon 5 runtime dependencies -->
+		<dependency>
+			<groupId>org.axonframework</groupId>
+			<artifactId>axon-messaging</artifactId>
+			<version>${axon5.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.axonframework</groupId>
+			<artifactId>axon-modelling</artifactId>
+			<version>${axon5.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.axonframework</groupId>
+			<artifactId>axon-eventsourcing</artifactId>
+			<version>${axon5.version}</version>
+		</dependency>
+
+		<!-- Testing -->
+		<dependency>
+			<groupId>org.axonframework</groupId>
+			<artifactId>axon-test</artifactId>
+			<version>${axon5.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.axonframework</groupId>
+			<artifactId>axon-conversion</artifactId>
+			<version>${axon5.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven.compiler.version}</version>
+				<configuration>
+					<source>17</source>
+					<target>17</target>
+					<encoding>${project.build.sourceEncoding}</encoding>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>io.github.joht.alias</groupId>
+							<artifactId>type-alias</artifactId>
+							<version>${project.version}</version>
+						</path>
+						<path>
+							<groupId>javax.annotation</groupId>
+							<artifactId>javax.annotation-api</artifactId>
+							<version>${annotation.api.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven.surefire.version}</version>
+				<configuration>
+					<includes>
+						<include>**/*IT.java</include>
+						<include>**/*Test.java</include>
+					</includes>
+					<systemPropertyVariables>
+						<user.language>en</user.language>
+						<user.country>US</user.country>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/type-alias-axon-5-serializer-integration-test/src/main/java/org/alias/axon/serializer/example/messages/DoSomethingCommand.java
+++ b/type-alias-axon-5-serializer-integration-test/src/main/java/org/alias/axon/serializer/example/messages/DoSomethingCommand.java
@@ -1,0 +1,25 @@
+package org.alias.axon.serializer.example.messages;
+
+import java.beans.ConstructorProperties;
+
+/**
+ * Example command used in the integration test to trigger publication of a {@link SomethingHappenedEvent}.
+ */
+public class DoSomethingCommand {
+
+	private final String aggregateId;
+
+	@ConstructorProperties({ "aggregateId" })
+	public DoSomethingCommand(String aggregateId) {
+		this.aggregateId = aggregateId;
+	}
+
+	public String getAggregateId() {
+		return aggregateId;
+	}
+
+	@Override
+	public String toString() {
+		return "DoSomethingCommand [aggregateId=" + aggregateId + "]";
+	}
+}

--- a/type-alias-axon-5-serializer-integration-test/src/main/java/org/alias/axon/serializer/example/messages/SomethingHappenedEvent.java
+++ b/type-alias-axon-5-serializer-integration-test/src/main/java/org/alias/axon/serializer/example/messages/SomethingHappenedEvent.java
@@ -1,0 +1,28 @@
+package org.alias.axon.serializer.example.messages;
+
+import java.beans.ConstructorProperties;
+
+import org.alias.annotation.TypeAlias;
+
+/**
+ * Example domain event annotated with {@link TypeAlias} to demonstrate alias-based message type resolution.
+ */
+@TypeAlias("SomethingHappened")
+public class SomethingHappenedEvent {
+
+	private final String aggregateId;
+
+	@ConstructorProperties({ "aggregateId" })
+	public SomethingHappenedEvent(String aggregateId) {
+		this.aggregateId = aggregateId;
+	}
+
+	public String getAggregateId() {
+		return aggregateId;
+	}
+
+	@Override
+	public String toString() {
+		return "SomethingHappenedEvent [aggregateId=" + aggregateId + "]";
+	}
+}

--- a/type-alias-axon-5-serializer-integration-test/src/main/java/org/alias/axon/serializer/example/messages/package-info.java
+++ b/type-alias-axon-5-serializer-integration-test/src/main/java/org/alias/axon/serializer/example/messages/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * This package contains the main API of the example application, represented by messages.
+ * <p>
+ * The {@link TypeAlias} annotation is used to define aliases for message types.* These aliases are collected by the type-alias annotation processor at compile time
+ * and written into the default {@code TypeAlias} resource bundle in the default package.
+ */
+package org.alias.axon.serializer.example.messages;
+
+import org.alias.annotation.TypeAlias;

--- a/type-alias-axon-5-serializer-integration-test/src/test/java/org/alias/axon/serializer/TypeAliasMessageTypeResolverIT.java
+++ b/type-alias-axon-5-serializer-integration-test/src/test/java/org/alias/axon/serializer/TypeAliasMessageTypeResolverIT.java
@@ -1,0 +1,95 @@
+package org.alias.axon.serializer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Optional;
+
+import org.alias.axon.serializer.example.messages.DoSomethingCommand;
+import org.alias.axon.serializer.example.messages.SomethingHappenedEvent;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.messaging.commandhandling.GenericCommandResultMessage;
+import org.axonframework.messaging.commandhandling.configuration.CommandHandlingModule;
+import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.eventhandling.EventSink;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.test.fixture.AxonTestFixture;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test that verifies {@link AliasableMessageTypeResolver} correctly resolves type aliases
+ * from the annotation-processor-generated {@code TypeAlias} resource bundle, and that these aliases
+ * are applied as the {@link MessageType} name when events are published within the Axon framework.
+ */
+public class TypeAliasMessageTypeResolverIT {
+
+	/**
+	 * Verifies that the {@link AliasableMessageTypeResolver} resolves the alias defined via
+	 * {@code @TypeAlias} on {@link SomethingHappenedEvent} using the annotation-processor-generated
+	 * {@code TypeAlias} resource bundle.
+	 */
+	@Test
+	void shouldResolveAliasFromAnnotation() {
+		// GIVEN: resolver backed by the generated TypeAlias resource bundle
+		MessageTypeResolver resolver = AliasableMessageTypeResolver
+				.aliasThroughDefaultResourceBundle(new ClassBasedMessageTypeResolver());
+
+		// WHEN: resolving the type of SomethingHappenedEvent
+		Optional<MessageType> result = resolver.resolve(SomethingHappenedEvent.class);
+
+		// THEN: the alias from @TypeAlias("SomethingHappened") is returned
+		assertThat(result.isPresent(), is(true));
+		assertThat(result.get().name(), is("SomethingHappened"));
+		assertThat(result.get().version(), is(MessageType.DEFAULT_VERSION));
+	}
+
+	/**
+	 * Verifies that when the {@link AliasableMessageTypeResolver} is configured in the Axon framework,
+	 * events published by a command handler carry the alias name as their {@link MessageType#name()}.
+	 */
+	@Test
+	void shouldPublishEventWithAliasedMessageType() {
+		// GIVEN: Axon framework configured with AliasableMessageTypeResolver
+		QualifiedName commandName = new QualifiedName(DoSomethingCommand.class);
+
+		AxonTestFixture fixture = AxonTestFixture.with(
+				EventSourcingConfigurer.create()
+						.registerCommandHandlingModule(
+								CommandHandlingModule.named("test").commandHandlers(
+										phase -> phase.commandHandler(
+												commandName,
+												config -> (cmd, ctx) -> {
+													MessageTypeResolver resolver = config.getComponent(MessageTypeResolver.class);
+													MessageType eventType = resolver.resolve(SomethingHappenedEvent.class).orElseThrow();
+													EventSink eventSink = config.getComponent(EventSink.class);
+													eventSink.publish(ctx, new GenericEventMessage(eventType, new SomethingHappenedEvent("id1")));
+													return MessageStream.just(new GenericCommandResultMessage(
+															new MessageType("result", MessageType.DEFAULT_VERSION), null));
+												}
+										)
+								)
+						)
+						.messaging(m -> m.registerMessageTypeResolver(
+								config -> AliasableMessageTypeResolver.aliasThroughDefaultResourceBundle(
+										new ClassBasedMessageTypeResolver())))
+		);
+
+		// WHEN: DoSomethingCommand is dispatched
+		// THEN: the published event carries the alias "SomethingHappened" as its message type name
+		fixture.given()
+				.noPriorActivity()
+				.when()
+				.command(new DoSomethingCommand("id1"))
+				.then()
+				.success()
+				.eventsSatisfy(events -> {
+					assertThat(events, hasSize(1));
+					assertThat(events.get(0).type().name(), is("SomethingHappened"));
+				});
+	}
+}

--- a/type-alias-axon-5-serializer/README.md
+++ b/type-alias-axon-5-serializer/README.md
@@ -1,0 +1,286 @@
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+# Type-Alias Message Type Resolver for Axon Framework 5
+
+A lightweight `MessageTypeResolver` implementation for Axon Framework 5 that uses type aliases instead of fully qualified class names. This reduces message payload size and enables cleaner, more maintainable event type naming.
+
+## Why Use Aliases?
+
+In Axon 5, `MessageType` is used to identify command and event types in the routing and serialization process. By default, Axon uses fully qualified class names (e.g., `org.example.events.OrderCreatedEvent`), which:
+
+- Are verbose and tightly coupled to package structure
+- Make refactoring (package moves) break event compatibility
+- Create larger message payloads
+- Are less user-friendly in message serialization formats
+
+By using aliases (e.g., `OrderCreated`), you gain:
+
+- **Backwards Compatibility**: Rename or move classes without breaking event deserialization
+- **Cleaner Naming**: Use simple, business-friendly names for event types
+- **Reduced Payload Size**: Shorter type names significantly reduce serialized message size, benefiting network bandwidth and event store storage
+- **Flexibility**: Update the alias mapping independently from code
+
+## Alternative Approaches in Axon 5
+
+Axon Framework 5 provides several built-in solutions for custom message type naming. Here's how they compare:
+
+### 1. Annotation-Based Approach (Simplest)
+
+Use `@Event`, `@Command`, or `@Query` annotations directly on your message classes:
+
+```java
+@Event(namespace = "orders", name = "OrderCreated", version = "1.0")
+public class OrderCreatedEvent {
+    private final String orderId;
+    // ...
+}
+
+@Command(namespace = "orders", name = "CreateOrder", version = "1.0")
+public class CreateOrderCommand {
+    private final String orderId;
+    // ...
+}
+```
+
+**Pros**: Built-in, no external dependencies, declarative  
+**Cons**: Distributed configuration (scattered across classes), no compile-time validation
+
+### 2. NamespaceMessageTypeResolver (Similar to Type-Alias)
+
+Axon 5's built-in centralized resolver for explicit mappings:
+
+```java
+NamespaceMessageTypeResolver resolver = NamespaceMessageTypeResolver
+    .namespace("orders")
+    .message(OrderCreatedEvent.class, "OrderCreated", "1.0")
+    .message(OrderShippedEvent.class, "OrderShipped", "1.0")
+    .fallback(new ClassBasedMessageTypeResolver());
+```
+
+**Pros**: Built-in, centralized configuration, fluent API, fallback support  
+**Cons**: Configuration-time only, no compile-time validation
+
+### 3. HierarchicalMessageTypeResolver (Gradual Migration)
+
+Chain resolvers together to support multiple resolution strategies:
+
+```java
+HierarchicalMessageTypeResolver resolver = new HierarchicalMessageTypeResolver(
+    newResolver,  // Try new aliases first
+    oldResolver   // Fall back to old class names
+);
+```
+
+**Pros**: Enables gradual migration from old to new message type names  
+**Cons**: Requires explicit chaining logic
+
+### 4. Type-Alias (This Library)
+
+Compile-time generated, annotation-based approach with centralized resource bundle:
+
+```java
+@TypeAlias("OrderCreated")
+public class OrderCreatedEvent { /* ... */ }
+```
+
+**Pros**:
+
+- Compile-time validation catches missing aliases before runtime
+- Single source of truth in generated `TypeAlias` resource bundle
+- Audit trail of all aliases (generated class documents mappings)
+- Shareable across multiple services/modules
+
+**Cons**:
+
+- Requires annotation processor setup
+- Additional dependency (type-alias library)
+- Slightly more complex build configuration
+
+## When to Use Type-Alias
+
+Choose **Type-Alias** if you need:
+
+✅ **Compile-time validation** - Catch configuration errors before runtime  
+✅ **Shared alias definitions** - Reuse the same `TypeAlias` resource bundle across multiple services  
+✅ **Centralized audit trail** - Generated `TypeAlias` class documents all message type mappings  
+✅ **Build-time guarantees** - Ensure every `@TypeAlias` annotation is properly processed  
+
+Choose **built-in alternatives** if you prefer:
+
+✅ **Simplicity** - Direct annotations or simple builder configuration  
+✅ **No dependencies** - Use only Axon Framework's native APIs  
+✅ **Flexibility** - Change mappings at runtime without recompilation  
+
+## How to Configure It
+
+### 1. Add the Dependency
+
+```xml
+<dependency>
+    <groupId>io.github.joht.alias</groupId>
+    <artifactId>type-alias-axon-5-serializer</artifactId>
+    <version>2.0.1-SNAPSHOT</version>
+</dependency>
+```
+
+### 2. Create Type Aliases
+
+Annotate your command and event classes with `@TypeAlias`:
+
+```java
+package org.example.orders.events;
+
+import org.alias.annotation.TypeAlias;
+
+@TypeAlias("OrderCreated")
+public class OrderCreatedEvent {
+    private final String orderId;
+    
+    public OrderCreatedEvent(String orderId) {
+        this.orderId = orderId;
+    }
+    
+    public String getOrderId() {
+        return orderId;
+    }
+}
+```
+
+### 3. Generate the Resource Bundle
+
+Create a `package-info.java` to trigger annotation processing:
+
+```java
+package org.example.orders.events;
+
+import org.alias.annotation.TypeAliases;
+```
+
+The `type-alias` annotation processor will automatically generate a `TypeAlias` resource bundle at compile time containing all `@TypeAlias` annotated types.
+
+### 4. Register the Resolver in Axon Configuration
+
+When configuring your Axon application, register the `AliasableMessageTypeResolver`:
+
+```java
+import org.alias.axon.serializer.AliasableMessageTypeResolver;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
+
+EventSourcingConfigurer configurer = EventSourcingConfigurer.create()
+    .messaging(m -> m.registerMessageTypeResolver(
+        config -> AliasableMessageTypeResolver.aliasThroughDefaultResourceBundle(
+            new ClassBasedMessageTypeResolver()
+        )
+    ));
+```
+
+For routing to work correctly with commands:
+
+- Commands are routed by the fully qualified name of the command class (via `QualifiedName`)
+- Events published through the resolver will use the alias name from the type resolver
+- The resolver falls back to the delegate resolver (default class-based) if no alias is found
+
+## ResourceBundle Structure
+
+The generated `TypeAlias` resource bundle is a Java `ListResourceBundle` with bidirectional mappings:
+
+```java
+import java.util.ListResourceBundle;
+import javax.annotation.Generated;
+
+@Generated("type-alias")
+public class TypeAlias extends ListResourceBundle {
+    @Override
+    protected Object[][] getContents() {
+        return new Object[][] {
+            // Alias -> Class (for deserialization hints)
+            { "OrderCreated", org.example.orders.events.OrderCreatedEvent.class },
+            // FQCN -> Alias (used by the resolver)
+            { "org.example.orders.events.OrderCreatedEvent", "OrderCreated" },
+        };
+    }
+}
+```
+
+The resolver looks up the fully qualified class name and retrieves the alias string value.
+
+## Using with Type-Alias Annotation Processor
+
+To avoid manual maintenance, use the `type-alias` annotation processor:
+
+1. Add the annotation processor dependency:
+
+```xml
+<dependency>
+    <groupId>io.github.joht.alias</groupId>
+    <artifactId>type-alias</artifactId>
+    <version>2.0.1-SNAPSHOT</version>
+    <optional>true</optional>
+    <scope>provided</scope>
+</dependency>
+```
+
+2. Configure Maven compiler with explicit annotation processor paths (required for Java 17+):
+
+```xml
+<plugin>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <configuration>
+        <annotationProcessorPaths>
+            <path>
+                <groupId>io.github.joht.alias</groupId>
+                <artifactId>type-alias</artifactId>
+                <version>2.0.1-SNAPSHOT</version>
+            </path>
+        </annotationProcessorPaths>
+    </configuration>
+</plugin>
+```
+
+3. Simply annotate classes, and the resource bundle will be generated automatically during compilation.
+
+## Complete Example
+
+See `type-alias-axon-5-serializer-integration-test` for a complete working example with:
+
+- Domain events and commands annotated with `@TypeAlias`
+- Integration tests demonstrating the resolver in action
+- Axon test fixture configuration with the resolver
+
+Run the example:
+
+```bash
+cd type-alias-axon-5-serializer-integration-test
+mvn test
+```
+
+## Axon 5 Specifics
+
+This module targets **Axon Framework 5.1.0** and later. Key differences from Axon 4:
+
+- **MessageTypeResolver**: Axon 5 uses a functional interface `MessageTypeResolver` instead of serializer decorators
+- **MessageType**: Encapsulates type name and version (e.g., `new MessageType("OrderCreated", "1.0")`)
+- **QualifiedName**: Used for command routing based on fully qualified class names
+- **Simpler Integration**: No need to decorate serializers; just register the resolver in messaging configuration
+
+For Axon 4 compatibility, use `type-alias-axon-serializer` instead.
+
+## Comparison Table
+
+| Feature | Type-Alias | Annotations | NamespaceResolver | HierarchicalResolver |
+|---------|-----------|-------------|-------------------|----------------------|
+| Built-in | ❌ | ✅ | ✅ | ✅ |
+| Centralized Config | ✅ | ❌ | ✅ | ❌ |
+| Compile-time Validation | ✅ | ❌ | ❌ | ❌ |
+| No Dependencies | ❌ | ✅ | ✅ | ✅ |
+| Shared Across Services | ✅ | ❌ | ❌ | ❌ |
+| Setup Complexity | Medium | Low | Medium | Low |
+| Gradual Migration | Via Fallback | Via Fallback | Via Fallback | ✅ Primary Use |
+
+## References
+
+- [Axon Framework Documentation](https://docs.axoniq.io)
+- [Axon 5 MessageTypeResolver API](https://docs.axoniq.io/reference-guide/axon-framework/messaging-concepts/message-type-resolution)
+- [type-alias Project](https://github.com/JohT/alias)
+- [Java Annotation Processing API](https://docs.oracle.com/en/java/javase/17/docs/api/java.compiler/javax/annotation/processing/package-summary.html)

--- a/type-alias-axon-5-serializer/pom.xml
+++ b/type-alias-axon-5-serializer/pom.xml
@@ -1,0 +1,80 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>io.github.joht.alias</groupId>
+		<artifactId>alias-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>type-alias-axon-5-serializer</artifactId>
+	<name>type-alias-axon-5-serializer</name>
+	<description>Contains a type alias aware MessageTypeResolver for Axon Framework 5.</description>
+	<url>https://github.com/JohT/alias/tree/main/type-alias-axon-5-serializer</url>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<axon5.version>5.1.0</axon5.version>
+	</properties>
+
+	<dependencies>
+		<!-- type-alias annotation + ResourceBundle structure (compile-time only) -->
+		<dependency>
+			<groupId>io.github.joht.alias</groupId>
+			<artifactId>type-alias</artifactId>
+			<version>${project.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Axon 5 messaging (MessageTypeResolver, MessageType) -->
+		<dependency>
+			<groupId>org.axonframework</groupId>
+			<artifactId>axon-messaging</artifactId>
+			<version>${axon5.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Testing -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>${mockito.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<finalName>${project.artifactId}</finalName>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>${maven.compiler.version}</version>
+					<configuration>
+						<source>17</source>
+						<target>17</target>
+						<encoding>${project.build.sourceEncoding}</encoding>
+						<compilerArgs>
+							<arg>-proc:none</arg>
+						</compilerArgs>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>

--- a/type-alias-axon-5-serializer/src/main/java/org/alias/axon/serializer/AliasableMessageTypeResolver.java
+++ b/type-alias-axon-5-serializer/src/main/java/org/alias/axon/serializer/AliasableMessageTypeResolver.java
@@ -1,0 +1,83 @@
+package org.alias.axon.serializer;
+
+import java.util.MissingResourceException;
+import java.util.Optional;
+import java.util.ResourceBundle;
+
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.MessageTypeResolver;
+
+/**
+ * A {@link MessageTypeResolver} that looks up type aliases from a {@link ResourceBundle} and delegates to a fallback
+ * resolver when no alias is found.
+ * <p>
+ * Use {@link #aliasThroughDefaultResourceBundle(MessageTypeResolver)} to apply aliases defined in the default
+ * {@value #DEFAULT_TYPE_ALIAS_RESOURCE_BUNDLE_NAME} resource bundle, or
+ * {@link #aliasThroughResourceBundle(MessageTypeResolver, ResourceBundle)} to supply an explicit bundle.
+ *
+ * @see #aliasThroughResourceBundle(MessageTypeResolver, ResourceBundle)
+ * @author JohT
+ */
+public class AliasableMessageTypeResolver implements MessageTypeResolver {
+
+    public static final String DEFAULT_TYPE_ALIAS_RESOURCE_BUNDLE_NAME = "TypeAlias";
+
+    private final MessageTypeResolver delegate;
+    private final ResourceBundle resourceBundle;
+
+    /**
+     * Creates a {@link MessageTypeResolver} that uses the default {@value #DEFAULT_TYPE_ALIAS_RESOURCE_BUNDLE_NAME}
+     * resource bundle to look up type aliases.
+     *
+     * @param delegate fallback {@link MessageTypeResolver}
+     * @return {@link MessageTypeResolver}
+     */
+    public static MessageTypeResolver aliasThroughDefaultResourceBundle(MessageTypeResolver delegate) {
+        return aliasThroughResourceBundle(delegate, ResourceBundle.getBundle(DEFAULT_TYPE_ALIAS_RESOURCE_BUNDLE_NAME));
+    }
+
+    /**
+     * Creates a {@link MessageTypeResolver} that uses the given {@link ResourceBundle} to look up type aliases.
+     * <p>
+     * The resource bundle must contain the fully qualified class name as key mapped to the alias as a {@link String}
+     * value.
+     *
+     * @param delegate       fallback {@link MessageTypeResolver}
+     * @param resourceBundle {@link ResourceBundle} with alias mappings
+     * @return {@link MessageTypeResolver}
+     */
+    public static MessageTypeResolver aliasThroughResourceBundle(MessageTypeResolver delegate, ResourceBundle resourceBundle) {
+        return new AliasableMessageTypeResolver(delegate, resourceBundle);
+    }
+
+    private AliasableMessageTypeResolver(MessageTypeResolver delegate, ResourceBundle resourceBundle) {
+        this.delegate = delegate;
+        this.resourceBundle = resourceBundle;
+    }
+
+    @Override
+    public Optional<MessageType> resolve(Class<?> payloadType) {
+        String alias = aliasFor(payloadType.getName());
+        if (alias != null && !alias.isEmpty()) {
+            return Optional.of(new MessageType(alias, MessageType.DEFAULT_VERSION));
+        }
+        return delegate.resolve(payloadType);
+    }
+
+    private String aliasFor(String typeName) {
+        try {
+            Object value = resourceBundle.getObject(typeName);
+            if (value instanceof String) {
+                return (String) value;
+            }
+        } catch (MissingResourceException ignored) {
+            // no alias registered — delegate
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "AliasableMessageTypeResolver [delegate=" + delegate + ", resourceBundle=" + resourceBundle + "]";
+    }
+}

--- a/type-alias-axon-5-serializer/src/main/java/org/alias/axon/serializer/package-info.java
+++ b/type-alias-axon-5-serializer/src/main/java/org/alias/axon/serializer/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * This package contains the API of the Axon 5 serializer extension.
+ * <p>
+ * Use
+ * {@link org.alias.axon.serializer.AliasableMessageTypeResolver#aliasThroughResourceBundle(org.axonframework.messaging.core.MessageTypeResolver, java.util.ResourceBundle)}
+ * to give your {@link org.axonframework.messaging.core.MessageTypeResolver} the ability to use aliases registered in the
+ * given {@link java.util.ResourceBundle}.
+ * 
+ * @see org.alias.axon.serializer.AliasableMessageTypeResolver
+ */
+package org.alias.axon.serializer;

--- a/type-alias-axon-5-serializer/src/test/java/org/alias/axon/serializer/AliasableMessageTypeResolverTest.java
+++ b/type-alias-axon-5-serializer/src/test/java/org/alias/axon/serializer/AliasableMessageTypeResolverTest.java
@@ -1,0 +1,155 @@
+package org.alias.axon.serializer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ListResourceBundle;
+import java.util.Optional;
+import java.util.ResourceBundle;
+
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.MessageTypeResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link AliasableMessageTypeResolver} in BDD style.
+ */
+@ExtendWith(MockitoExtension.class)
+class AliasableMessageTypeResolverTest {
+
+    private static final String ALIAS = "SomethingHappened";
+    private static final String FQCN = SomethingHappenedEvent.class.getName();
+    private static final MessageType DELEGATE_RESULT = new MessageType("DelegateResult", MessageType.DEFAULT_VERSION);
+
+    @Mock
+    private MessageTypeResolver delegate;
+
+    private ResourceBundle bundleWithAlias;
+    private ResourceBundle emptyBundle;
+
+    @BeforeEach
+    void setUp() {
+        bundleWithAlias = new ListResourceBundle() {
+            @Override
+            protected Object[][] getContents() {
+                return new Object[][] { { FQCN, ALIAS } };
+            }
+        };
+        emptyBundle = new ListResourceBundle() {
+            @Override
+            protected Object[][] getContents() {
+                return new Object[][] {};
+            }
+        };
+    }
+
+    // --- Given alias in ResourceBundle ---
+
+    @Test
+    void shouldReturnAliasWhenFoundInResourceBundle() {
+        // Given
+        MessageTypeResolver resolver = AliasableMessageTypeResolver.aliasThroughResourceBundle(delegate, bundleWithAlias);
+
+        // When
+        Optional<MessageType> result = resolver.resolve(SomethingHappenedEvent.class);
+
+        // Then
+        assertThat("Expected alias MessageType to be present", result.isPresent(), is(true));
+        assertThat("Expected alias name", result.get().name(), equalTo(ALIAS));
+        assertThat("Expected DEFAULT_VERSION", result.get().version(), equalTo(MessageType.DEFAULT_VERSION));
+        verifyNoMoreInteractions(delegate);
+    }
+
+    // --- Given no alias in ResourceBundle ---
+
+    @Test
+    void shouldDelegateWhenNoAliasFound() {
+        // Given
+        when(delegate.resolve(SomethingHappenedEvent.class)).thenReturn(Optional.of(DELEGATE_RESULT));
+        MessageTypeResolver resolver = AliasableMessageTypeResolver.aliasThroughResourceBundle(delegate, emptyBundle);
+
+        // When
+        Optional<MessageType> result = resolver.resolve(SomethingHappenedEvent.class);
+
+        // Then
+        assertThat("Expected delegate result", result, equalTo(Optional.of(DELEGATE_RESULT)));
+        verify(delegate).resolve(SomethingHappenedEvent.class);
+    }
+
+    // --- Given ResourceBundle entry with non-String value ---
+
+    @Test
+    void shouldDelegateWhenResourceBundleValueIsNotAString() {
+        // Given
+        ResourceBundle bundleWithNonStringValue = new ListResourceBundle() {
+            @Override
+            protected Object[][] getContents() {
+                return new Object[][] { { FQCN, Integer.valueOf(42) } };
+            }
+        };
+        when(delegate.resolve(SomethingHappenedEvent.class)).thenReturn(Optional.of(DELEGATE_RESULT));
+        MessageTypeResolver resolver = AliasableMessageTypeResolver.aliasThroughResourceBundle(delegate, bundleWithNonStringValue);
+
+        // When
+        Optional<MessageType> result = resolver.resolve(SomethingHappenedEvent.class);
+
+        // Then
+        assertThat("Expected delegate result when value is not a String", result, equalTo(Optional.of(DELEGATE_RESULT)));
+        verify(delegate).resolve(SomethingHappenedEvent.class);
+    }
+
+    // --- Given empty string alias in ResourceBundle ---
+
+    @Test
+    void shouldDelegateWhenAliasIsEmpty() {
+        // Given
+        ResourceBundle bundleWithEmptyAlias = new ListResourceBundle() {
+            @Override
+            protected Object[][] getContents() {
+                return new Object[][] { { FQCN, "" } };
+            }
+        };
+        when(delegate.resolve(SomethingHappenedEvent.class)).thenReturn(Optional.of(DELEGATE_RESULT));
+        MessageTypeResolver resolver = AliasableMessageTypeResolver.aliasThroughResourceBundle(delegate, bundleWithEmptyAlias);
+
+        // When
+        Optional<MessageType> result = resolver.resolve(SomethingHappenedEvent.class);
+
+        // Then
+        assertThat("Expected delegate result when alias is empty", result, equalTo(Optional.of(DELEGATE_RESULT)));
+        verify(delegate).resolve(SomethingHappenedEvent.class);
+    }
+
+    // --- Given multiple types, only one with alias ---
+
+    @Test
+    void shouldOnlyAliasTypesRegisteredInResourceBundle() {
+        // Given
+        MessageTypeResolver resolver = AliasableMessageTypeResolver.aliasThroughResourceBundle(delegate, bundleWithAlias);
+        when(delegate.resolve(UnregisteredEvent.class)).thenReturn(Optional.of(DELEGATE_RESULT));
+
+        // When
+        Optional<MessageType> aliasedResult = resolver.resolve(SomethingHappenedEvent.class);
+        Optional<MessageType> unregisteredResult = resolver.resolve(UnregisteredEvent.class);
+
+        // Then
+        assertThat("Expected alias for registered type", aliasedResult.get().name(), equalTo(ALIAS));
+        assertThat("Expected delegate result for unregistered type", unregisteredResult, equalTo(Optional.of(DELEGATE_RESULT)));
+    }
+
+    // --- Test helper inner classes ---
+
+    private static final class SomethingHappenedEvent {
+    }
+
+    private static final class UnregisteredEvent {
+    }
+}


### PR DESCRIPTION
## 🚀 Features

- [Add type alias serializer for axon 5.](https://github.com/JohT/alias/pull/517/commits/f37fa772f41abdab22e5b2f9802f07fef4be346c): Adds a new Axon Framework 5 adapter module that enables resolving MessageType names via type-alias ResourceBundle entries, plus a minimal integration-test module demonstrating end-to-end alias usage within Axon.

## ⚙️ Optimizations

- [Fix markdown linting warnings](https://github.com/JohT/alias/pull/517/commits/104920cbc38538400534ed7801be9fa767a3154d)